### PR TITLE
Enhancements to Streamline SSO Dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,3 @@ htmlcov/*
 /examples/example_plugin/example_plugin/static/example_plugin/docs/
 # Allow separate ENV file for keycloak and ignore the templated keycloak configuration
 !keycloak.env
-nautobot-realms.json

--- a/development/docker-compose.keycloak.yml
+++ b/development/docker-compose.keycloak.yml
@@ -1,6 +1,9 @@
 ---
 version: "3.4"
 services:
+  nautobot:
+    environment:
+      - "ENABLE_OIDC=True"
   keycloak:
     image: "quay.io/keycloak/keycloak:21.0"
     env_file:
@@ -15,7 +18,6 @@ services:
       - start-dev
       - --import-realm
       - --http-port=8087
-
   keycloak_db:
     image: postgres:13
     env_file:

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -15,9 +15,6 @@ services:
       - redis
       - selenium
       - db
-    environment:
-      - ENABLE_OIDC=${ENABLE_OIDC}
-      - SSO_HOST=${SSO_HOST}
     env_file:
       - dev.env
     tty: true

--- a/development/nautobot-realms.json
+++ b/development/nautobot-realms.json
@@ -1,11 +1,4 @@
-{#
-	This template is an export from Keycloak.
-	See https://github.com/keycloak/keycloak-documentation/blob/main/server_admin/topics/export-import.adoc for instructions on how to run the export.
-	Once you have the export you want to variablize the public cert, private cert, and the endpoints.
 
-	Additionally, when you run the export from Keycloak it will export everything in the realm, this is not needed for import.
-	Look at the fields in the JSON and remove any additional fields that comes from your export that you don't need.
-#}
 {
   "id": "Nautobot Realm",
   "realm": "nautobot",
@@ -155,7 +148,6 @@
       "clientAuthenticatorType": "client-secret",
       "secret": "7b1c3527-8702-4742-af69-2b74ee5742e8",
       "redirectUris": [
-        "{{ nautobot_host }}/complete/keycloak/",
         "http://localhost:8080/complete/keycloak/"
       ],
       "webOrigins": [],

--- a/development/nautobot_config.py
+++ b/development/nautobot_config.py
@@ -57,4 +57,3 @@ if is_truthy(os.getenv("ENABLE_OIDC", "False")):
     SOCIAL_AUTH_KEYCLOAK_VERIFY_SSL = False
 
 METRICS_ENABLED = True
-

--- a/development/nautobot_config.py
+++ b/development/nautobot_config.py
@@ -52,9 +52,7 @@ if is_truthy(os.getenv("ENABLE_OIDC", "False")):
     SOCIAL_AUTH_KEYCLOAK_KEY = "nautobot"
     SOCIAL_AUTH_KEYCLOAK_SECRET = "7b1c3527-8702-4742-af69-2b74ee5742e8"
     SOCIAL_AUTH_KEYCLOAK_PUBLIC_KEY = requests.get("http://keycloak:8087/realms/nautobot/").json()["public_key"]
-    SOCIAL_AUTH_KEYCLOAK_AUTHORIZATION_URL = (
-        f"{ os.getenv('SSO_HOST') }/realms/nautobot/protocol/openid-connect/auth"
-    )
+    SOCIAL_AUTH_KEYCLOAK_AUTHORIZATION_URL = "http://localhost:8087/realms/nautobot/protocol/openid-connect/auth"
     SOCIAL_AUTH_KEYCLOAK_ACCESS_TOKEN_URL = "http://keycloak:8087/realms/nautobot/protocol/openid-connect/token"
     SOCIAL_AUTH_KEYCLOAK_VERIFY_SSL = False
 

--- a/invoke.yml.example
+++ b/invoke.yml.example
@@ -34,6 +34,3 @@ nautobot:
 #     - "docker-compose.mysql.yml"
 #     - "docker-compose.dev.yml"
 #     - "docker-compose.keycloak.yml"
-#   enable_oidc: "True"
-#   sso_host: "http://localhost:8087"
-#   nautobot_host: "http://localhost:8080"

--- a/nautobot/docs/development/sso.md
+++ b/nautobot/docs/development/sso.md
@@ -10,11 +10,6 @@ Keycloak is run in the same docker-compose project as Nautobot and has it own se
 
 The `invoke.yml` file must be updated to add `development/docker-compose.keycloak.yml` to the docker-compose project and to enable OIDC. These setting are solely for local development inside the Nautobot repository and is not applicable to any other deployment.
 
-* enable_oidc - Stringified boolean value that must be set to `"True"` for the `nautobot_config.py` load the SSO configuration.
-* sso_host - This is the base url for Keycloak that is accessible for the user, default value is for running the development environment on `localhost` only overload if performing remote development.
-* nautobot_host - This is the base url for Nautobot that is accessible for the user, default value is for running the development environment on `localhost` only overload if performing remote development.
-* compose_files - List of docker-compose files needed for nautobot deployment.
-
 #### Example invoke.yml
 
 Example running development environment on localhost.
@@ -27,7 +22,6 @@ nautobot:
     - "docker-compose.postgres.yml"
     - "docker-compose.dev.yml"
     - "docker-compose.keycloak.yml"
-  enable_oidc: "True"
 ```
 
 Example running development environment on remote host.
@@ -40,9 +34,6 @@ nautobot:
     - "docker-compose.postgres.yml"
     - "docker-compose.dev.yml"
     - "docker-compose.keycloak.yml"
-  enable_oidc: "True"
-  sso_host: "http://192.168.0.2:8087"
-  nautobot_host: "http://192.168.0.2:8080"
 ```
 
 ### Provisioning Keycloak
@@ -61,10 +52,10 @@ Once all steps are completed Nautobot should now have the `Continue to SSO` butt
 
 ### Keycloak Login Credentials
 
-Keycloak admin console is reachable via `http://localhost:8087/` with user `admin` and password `admin`. The below users are pre-configured within Keycloak, at this time their permissions are not directly mapped to any permissions provided by default by Nautobot. This will be a later enhancement to the local development environment.
+Keycloak admin console is reachable via `http://localhost:8087/admin/` with user `admin` and password `admin`. The below users are pre-configured within Keycloak, at this time their permissions are not directly mapped to any permissions provided by default by Nautobot. This will be a later enhancement to the local development environment.
 
 | Username         | Password  |
 +------------------+-----------+
 | nautobot_unpriv  | unpriv123 |
-| nautonot_admin   | admin123  |
+| nautobot_admin   | admin123  |
 | nautobot_auditor | audit123  |

--- a/tasks.py
+++ b/tasks.py
@@ -71,12 +71,6 @@ namespace.configure(
                 "networktocode/nautobot-dev",
                 "ghcr.io/nautobot/nautobot-dev",
             ],
-            # Development SSO Configuration
-            "enable_saml": "False",
-            "enable_oidc": "False",
-            # Endpoint reachable by user's browser
-            "sso_host": "http://localhost:8087",
-            "nautobot_host": "http://localhost:8080",
         }
     }
 )
@@ -167,9 +161,6 @@ def docker_compose(context, command, **kwargs):
     env.update(
         {
             "PYTHON_VER": context.nautobot.python_ver,
-            "ENABLE_SAML": context.nautobot.enable_saml,
-            "ENABLE_OIDC": context.nautobot.enable_oidc,
-            "SSO_HOST": context.nautobot.sso_host,
         }
     )
     if "hide" not in kwargs:

--- a/tasks.py
+++ b/tasks.py
@@ -158,11 +158,7 @@ def docker_compose(context, command, **kwargs):
     print(f'Running docker-compose command "{command}"')
     compose_command = " ".join(compose_command_tokens)
     env = kwargs.pop("env", {})
-    env.update(
-        {
-            "PYTHON_VER": context.nautobot.python_ver,
-        }
-    )
+    env.update({"PYTHON_VER": context.nautobot.python_ver})
     if "hide" not in kwargs:
         print_command(compose_command, env=env)
     return context.run(compose_command, env=env, **kwargs)
@@ -542,19 +538,6 @@ def build_example_plugin_docs(context):
     else:
         docker_command = f"run --workdir='/source/examples/example_plugin' --entrypoint '{command}' nautobot"
         docker_compose(context, docker_command, pty=True)
-
-
-@task()
-def provision_sso(context):
-    """Templates Keycloak configurations and applies to keycloak container."""
-    try:
-        from jinja2 import Environment, FileSystemLoader
-    except ImportError:
-        raise ImportError("Unable to import Jinja, install & activate poetry virtual-env to run this command.")
-    template = Environment(loader=FileSystemLoader("development/")).get_template("nautobot-realms.json.j2")
-    content = template.render(nautobot_host=context.nautobot.nautobot_host)
-    with open("development/nautobot-realms.json", mode="w", encoding="utf-8") as file:
-        file.write(content)
 
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
# What's Changed
- Environment variable changes are included in the Keycloak compose file
- Remove requirement for `provision_sso`
    - Because of upstream changes to ALLOWED_HOSTS enforcement in dev, additional config is needed to get Nautobot to respond to anything but `http://localhost:8080`. This exception can be extended to the Keycloak config as well.
- Update docs

With these changes, add `docker-compose.keycloak.yml` to your `invoke.yml` and 🎉 you have SSO. Remove it, SSO is disabled.

# TODO
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [X] Explanation of Change(s)
- [NA] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [NA] Attached Screenshots, Payload Example
- [NA] Unit, Integration Tests
- [X] Documentation Updates (when adding/changing features)
- [NA] Example Plugin Updates (when adding/changing features)
- [NA] Outline Remaining Work, Constraints from Design
